### PR TITLE
Declare support for Java 8

### DIFF
--- a/src/main/java/com/amazonaws/eclipse/simpleworkflow/asynchrony/annotationprocessor/AsynchronyDeciderAnnotationProcessor.java
+++ b/src/main/java/com/amazonaws/eclipse/simpleworkflow/asynchrony/annotationprocessor/AsynchronyDeciderAnnotationProcessor.java
@@ -40,7 +40,7 @@ import com.amazonaws.services.simpleworkflow.flow.annotations.Workflow;
 
 @SupportedAnnotationTypes({ "com.amazonaws.services.simpleworkflow.flow.annotations.Activities",
         "com.amazonaws.services.simpleworkflow.flow.annotations.Workflow" })
-@SupportedSourceVersion(SourceVersion.RELEASE_7)
+@SupportedSourceVersion(SourceVersion.RELEASE_8)
 public class AsynchronyDeciderAnnotationProcessor extends AbstractProcessor {
 
     private Set<DeclaredType> annotationsToExcludeFromCopying;


### PR DESCRIPTION
The annotation processor supports Java 8 sources without any issue.