### PR TITLE
Migrate AWS SWF Build project to have AWS SDK v2 compatible code

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-swf-build-tools</artifactId>
-    <version>1.1</version>
+    <version>2.0.0</version>
     <packaging>jar</packaging>
 
     <name>AWS SWF Build Tools</name>
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <freemarker.version>2.3.9</freemarker.version>
         <aspectj.version>1.8.2</aspectj.version>
-        <jre.version>1.6</jre.version>
+        <jre.version>1.8</jre.version>
         <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
 
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-swf-libraries</artifactId>
-            <version>[1.10.69,)</version>
+            <version>[2.0.0,)</version>
         </dependency>
         <dependency>
             <groupId>org.freemarker</groupId>
@@ -80,9 +80,9 @@
               </execution>
             </executions>
             <configuration>
-              <complianceLevel>1.6</complianceLevel>
-              <source>1.6</source>
-              <target>1.6</target>
+              <complianceLevel>1.8</complianceLevel>
+              <source>1.8</source>
+              <target>1.8</target>
               <encoding>UTF-8</encoding>
             </configuration>
           </plugin>

--- a/src/main/resources/resources/templates/activitiesclientimpl.ftl
+++ b/src/main/resources/resources/templates/activitiesclientimpl.ftl
@@ -62,9 +62,8 @@
     protected Promise<${activityMethod.methodReturnType}> ${activityImplMethodName}(final ActivitySchedulingOptions optionsOverride, Promise<?>... waitFor) {
 </#if>
 
-        ActivityType _activityType = new ActivityType();
-		_activityType.setName("${activityName}");
-		_activityType.setVersion("${activityVersion}");
+        ActivityType _activityType = ActivityType.builder()
+           .name("${activityName}").version("${activityVersion}").build();
 
         Promise[] _input_ = new Promise[${parameterCount}];
 <#list activityMethod.methodParameters as param>
@@ -83,7 +82,7 @@ import com.amazonaws.services.simpleworkflow.flow.ActivitySchedulingOptions;
 import com.amazonaws.services.simpleworkflow.flow.DataConverter;
 import com.amazonaws.services.simpleworkflow.flow.core.Promise;
 import com.amazonaws.services.simpleworkflow.flow.generic.GenericActivityClient;
-import com.amazonaws.services.simpleworkflow.model.ActivityType;
+import com.amazonaws.services.simpleworkflow.flow.model.ActivityType;
 
 public class ${clientImplName} extends ActivitiesClientBase implements ${clientInterfaceName} {
 

--- a/src/main/resources/resources/templates/workflowclientexternalfactoryimpl.ftl
+++ b/src/main/resources/resources/templates/workflowclientexternalfactoryimpl.ftl
@@ -1,21 +1,27 @@
 <#include "header.ftl">
 package ${packageName};
 
-import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflow;
+import software.amazon.awssdk.services.swf.SwfClient;
 import com.amazonaws.services.simpleworkflow.flow.DataConverter;
 import com.amazonaws.services.simpleworkflow.flow.StartWorkflowOptions;
 import com.amazonaws.services.simpleworkflow.flow.WorkflowClientFactoryExternalBase;
 import com.amazonaws.services.simpleworkflow.flow.generic.GenericWorkflowClientExternal;
-import com.amazonaws.services.simpleworkflow.model.WorkflowExecution;
-import com.amazonaws.services.simpleworkflow.model.WorkflowType;
+import com.amazonaws.services.simpleworkflow.flow.config.SimpleWorkflowClientConfig;
+import com.amazonaws.services.simpleworkflow.flow.model.WorkflowExecution;
+import com.amazonaws.services.simpleworkflow.flow.model.WorkflowType;
 
 public class ${clientExternalFactoryImplName} extends WorkflowClientFactoryExternalBase<${clientExternalInterfaceName}>  implements ${clientExternalFactoryName} {
 
-    public ${clientExternalFactoryImplName}(AmazonSimpleWorkflow service, String domain) {
+    public ${clientExternalFactoryImplName}(SwfClient service, String domain) {
 		super(service, domain);
 		setDataConverter(new ${workflow.dataConverter}());
 	}
-	
+
+    public ${clientExternalFactoryImplName}(SwfClient service, String domain, SimpleWorkflowClientConfig config) {
+        super(service, domain, config);
+        setDataConverter(new ${workflow.dataConverter}());
+    }
+
 	public ${clientExternalFactoryImplName}() {
         super(null);
 		setDataConverter(new ${workflow.dataConverter}());
@@ -33,9 +39,8 @@ public class ${clientExternalFactoryImplName} extends WorkflowClientFactoryExter
 <#assign executeMethod = workflow.executeMethod>
 <#assign workflowName = executeMethod.workflowName>
 <#assign workflowVersion = executeMethod.workflowVersion>
-        WorkflowType workflowType = new WorkflowType();
-        workflowType.setName("${workflowName}");
-        workflowType.setVersion("${workflowVersion}");
+        WorkflowType workflowType = WorkflowType.builder()
+            .name("${workflowName}").version("${workflowVersion}").build();
         return new ${clientExternalImplName}(workflowExecution, workflowType, options, dataConverter, genericClient);
 <#else>
         return new ${clientExternalImplName}(workflowExecution, null, options, dataConverter, genericClient);

--- a/src/main/resources/resources/templates/workflowclientexternalimpl.ftl
+++ b/src/main/resources/resources/templates/workflowclientexternalimpl.ftl
@@ -90,8 +90,8 @@ import com.amazonaws.services.simpleworkflow.flow.DataConverter;
 import com.amazonaws.services.simpleworkflow.flow.StartWorkflowOptions;
 import com.amazonaws.services.simpleworkflow.flow.WorkflowClientExternalBase;
 import com.amazonaws.services.simpleworkflow.flow.generic.GenericWorkflowClientExternal;
-import com.amazonaws.services.simpleworkflow.model.WorkflowExecution;
-import com.amazonaws.services.simpleworkflow.model.WorkflowType;
+import com.amazonaws.services.simpleworkflow.flow.model.WorkflowExecution;
+import com.amazonaws.services.simpleworkflow.flow.model.WorkflowType;
 
 class ${clientExternalImplName} extends WorkflowClientExternalBase implements ${clientExternalInterfaceName} {
 

--- a/src/main/resources/resources/templates/workflowclientfactoryimpl.ftl
+++ b/src/main/resources/resources/templates/workflowclientfactoryimpl.ftl
@@ -5,8 +5,8 @@ import com.amazonaws.services.simpleworkflow.flow.DataConverter;
 import com.amazonaws.services.simpleworkflow.flow.StartWorkflowOptions;
 import com.amazonaws.services.simpleworkflow.flow.WorkflowClientFactoryBase;
 import com.amazonaws.services.simpleworkflow.flow.generic.GenericWorkflowClient;
-import com.amazonaws.services.simpleworkflow.model.WorkflowExecution;
-import com.amazonaws.services.simpleworkflow.model.WorkflowType;
+import com.amazonaws.services.simpleworkflow.flow.model.WorkflowExecution;
+import com.amazonaws.services.simpleworkflow.flow.model.WorkflowType;
 
 public class ${clientFactoryImplName} extends WorkflowClientFactoryBase<${clientInterfaceName}> implements ${clientFactoryName} {
     
@@ -24,7 +24,7 @@ public class ${clientFactoryImplName} extends WorkflowClientFactoryBase<${client
 
     public ${clientFactoryImplName}(StartWorkflowOptions startWorkflowOptions, DataConverter dataConverter,
             GenericWorkflowClient genericClient) {
-        super(startWorkflowOptions, new ${workflow.dataConverter}(), genericClient);
+        super(startWorkflowOptions, dataConverter, genericClient);
     }
     
     @Override
@@ -34,9 +34,8 @@ public class ${clientFactoryImplName} extends WorkflowClientFactoryBase<${client
 <#assign executeMethod = workflow.executeMethod>
 <#assign workflowName = executeMethod.workflowName>
 <#assign workflowVersion = executeMethod.workflowVersion>
-        WorkflowType workflowType = new WorkflowType();
-        workflowType.setName("${workflowName}");
-        workflowType.setVersion("${workflowVersion}");
+        WorkflowType workflowType = WorkflowType.builder()
+          .name("${workflowName}").version("${workflowVersion}").build();
         return new ${clientImplName}(execution, workflowType, options, dataConverter, genericClient);
 <#else>
         return new ${clientImplName}(execution, null, options, dataConverter, genericClient);

--- a/src/main/resources/resources/templates/workflowclientimpl.ftl
+++ b/src/main/resources/resources/templates/workflowclientimpl.ftl
@@ -87,8 +87,8 @@ import com.amazonaws.services.simpleworkflow.flow.StartWorkflowOptions;
 import com.amazonaws.services.simpleworkflow.flow.WorkflowClientBase;
 import com.amazonaws.services.simpleworkflow.flow.core.Promise;
 import com.amazonaws.services.simpleworkflow.flow.generic.GenericWorkflowClient;
-import com.amazonaws.services.simpleworkflow.model.WorkflowExecution;
-import com.amazonaws.services.simpleworkflow.model.WorkflowType;
+import com.amazonaws.services.simpleworkflow.flow.model.WorkflowExecution;
+import com.amazonaws.services.simpleworkflow.flow.model.WorkflowType;
 
 class ${clientImplName} extends WorkflowClientBase implements ${clientInterfaceName} {
 

--- a/src/main/resources/resources/templates/workflowselfclientimpl.ftl
+++ b/src/main/resources/resources/templates/workflowselfclientimpl.ftl
@@ -1,14 +1,10 @@
 <#include "header.ftl">
 <#import "common.ftl" as lib>
+<#macro generateExecuteMethodImpl workflow>
 <#if workflow.executeMethod??>
 <#assign executeMethod = workflow.executeMethod>
 <#assign parameterCount = executeMethod.methodParameters?size>
 <#assign hasParametersAndExecute = (parameterCount > 0)>
-<#else>
-<#assign hasParametersAndExecute = false>
-</#if>
-<#macro generateExecuteMethodImpl workflow>
-<#if workflow.executeMethod??>
 <#assign workflowImplMethodName = "${executeMethod.methodName}Impl">
 <#if hasParametersAndExecute>
     @Override
@@ -82,9 +78,7 @@
 </#macro>
 package ${packageName};
 
-<#if hasParametersAndExecute>
 import com.amazonaws.services.simpleworkflow.flow.core.AndPromise;
-</#if>
 import com.amazonaws.services.simpleworkflow.flow.core.Promise;
 import com.amazonaws.services.simpleworkflow.flow.core.Task;
 import com.amazonaws.services.simpleworkflow.flow.DataConverter;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Upgrade AWS SDK to v2 for the Flow Framework
* Updated the client generation template to consider custom model entity created for `WorkflowExecution, Workflowtype and ActivityType ` under the package `com.amazonaws.services.simpleworkflow.flow.model`
* Updated compliance level for AspectJ weaving to be at Java `1.8`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
